### PR TITLE
Style: use blockquote for RFP samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Building Accessibility Best Practices into Contracting
 
 ## Most RFPs that talk about accessibility include something like:
 
-    We require that all purchases be accessible according to the Web Accessibility Initiative 
-    (WAI) Web Content Accessibility Guidelines 2.0 AA. 
+> We require that all purchases be accessible according to the Web Accessibility Initiative 
+> (WAI) Web Content Accessibility Guidelines 2.0 AA. 
 
 **or**
 
-    All content, interfaces, and navigation elements to be used for this project must be 
-    compliant with Web Accessibility Initiative (WAI) Web Content Accessibility Guidelines 2.0 AA. 
-    Compliance means that a person with a disability can percieve, operate and understand the 
-    interface the same as a person without a disability.
+> All content, interfaces, and navigation elements to be used for this project must be 
+> compliant with Web Accessibility Initiative (WAI) Web Content Accessibility Guidelines 2.0 AA. 
+> Compliance means that a person with a disability can percieve, operate and understand the 
+> interface the same as a person without a disability.
 
 ## Concerns
 - Don't ask that a vendor commit to making a site meet a set accessibility target if there isn't a clearly defined set of deliverables or a flexible budget. 


### PR DESCRIPTION
Since these sample texts come from other documents (albeit hypothetical ones), blockquote is appropriate.

Previously these were indented code samples. This had some problems:

- The semantics are wrong. These RFP samples aren't programming code; they are English.
- Markdown treats them as pre-formatted text, but there's no need for this. They're just sentences, not tables or anything where the line breaks matter.
- In a narrow viewport, these blocks have a scrolling horizontal overflow. This is a failure of WCAG SC 1.4.10 Reflow.